### PR TITLE
change CurlRequest.body to type Object from string

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -49,7 +49,7 @@ type CurlAdditionalOptions = {
 type CurlRequest = {
   method?: "GET" | "get" | "POST" | "post" | "PUT" | "put" | "PATCH" | "patch" | "DELETE" | "delete",
   headers?: StringMap,
-  body?: string,
+  body?: Object,
   url: string,
 };
 


### PR DESCRIPTION
Hi,
I am using your package in TypeScript but can't set a body that is type `Object` in `CurlRequest.body`  because it is defined as `string`.
Thanks!