### PR TITLE
Allow custom method with optional parameter 'noValidation'

### DIFF
--- a/dist/curl-generator.cjs.js
+++ b/dist/curl-generator.cjs.js
@@ -89,24 +89,30 @@ var slash = " \\";
 var newLine = "\n";
 /**
  * @param {string} [method]
+ * @param {boolean} [noValidation]
  * @returns {string}
  */
-var getCurlMethod = function (method) {
+var getCurlMethod = function (method, noValidation) {
     var result = "";
     if (method) {
-        var types = {
-            GET: "-X GET",
-            POST: "-X POST",
-            PUT: "-X PUT",
-            PATCH: "-X PATCH",
-            DELETE: "-X DELETE",
-            HEAD: "-X HEAD",
-            OPTIONS: "-X OPTIONS",
-            CONNECT: "-X CONNECT",
-            TRACE: "-X TRACE",
-            QUERY: "-X QUERY",
-        };
-        result = " " + types[method.toUpperCase()];
+        if (noValidation) {
+            result = " -X " + method;
+        }
+        else {
+            var types = {
+                GET: "-X GET",
+                POST: "-X POST",
+                PUT: "-X PUT",
+                PATCH: "-X PATCH",
+                DELETE: "-X DELETE",
+                HEAD: "-X HEAD",
+                OPTIONS: "-X OPTIONS",
+                CONNECT: "-X CONNECT",
+                TRACE: "-X TRACE",
+                QUERY: "-X QUERY",
+            };
+            result = " " + types[method.toUpperCase()];
+        }
     }
     return slash + newLine + result;
 };
@@ -167,7 +173,7 @@ var getCurlOptions = function (options) {
 var CurlGenerator = function (params, options) {
     var curlSnippet = "curl ";
     curlSnippet += params.url;
-    curlSnippet += getCurlMethod(params.method);
+    curlSnippet += getCurlMethod(params.method, params.noValidation);
     curlSnippet += getCurlHeaders(params.headers);
     curlSnippet += getCurlBody(params.body);
     curlSnippet += getCurlOptions(options);

--- a/dist/curl-generator.esm.js
+++ b/dist/curl-generator.esm.js
@@ -85,24 +85,30 @@ var slash = " \\";
 var newLine = "\n";
 /**
  * @param {string} [method]
+ * @param {boolean} [noValidation]
  * @returns {string}
  */
-var getCurlMethod = function (method) {
+var getCurlMethod = function (method, noValidation) {
     var result = "";
     if (method) {
-        var types = {
-            GET: "-X GET",
-            POST: "-X POST",
-            PUT: "-X PUT",
-            PATCH: "-X PATCH",
-            DELETE: "-X DELETE",
-            HEAD: "-X HEAD",
-            OPTIONS: "-X OPTIONS",
-            CONNECT: "-X CONNECT",
-            TRACE: "-X TRACE",
-            QUERY: "-X QUERY",
-        };
-        result = " " + types[method.toUpperCase()];
+        if (noValidation) {
+            result = " -X " + method;
+        }
+        else {
+            var types = {
+                GET: "-X GET",
+                POST: "-X POST",
+                PUT: "-X PUT",
+                PATCH: "-X PATCH",
+                DELETE: "-X DELETE",
+                HEAD: "-X HEAD",
+                OPTIONS: "-X OPTIONS",
+                CONNECT: "-X CONNECT",
+                TRACE: "-X TRACE",
+                QUERY: "-X QUERY",
+            };
+            result = " " + types[method.toUpperCase()];
+        }
     }
     return slash + newLine + result;
 };
@@ -163,7 +169,7 @@ var getCurlOptions = function (options) {
 var CurlGenerator = function (params, options) {
     var curlSnippet = "curl ";
     curlSnippet += params.url;
-    curlSnippet += getCurlMethod(params.method);
+    curlSnippet += getCurlMethod(params.method, params.noValidation);
     curlSnippet += getCurlHeaders(params.headers);
     curlSnippet += getCurlBody(params.body);
     curlSnippet += getCurlOptions(options);

--- a/dist/curl-generator.umd.js
+++ b/dist/curl-generator.umd.js
@@ -91,24 +91,30 @@
   var newLine = "\n";
   /**
    * @param {string} [method]
+   * @param {boolean} [noValidation]
    * @returns {string}
    */
-  var getCurlMethod = function (method) {
+  var getCurlMethod = function (method, noValidation) {
       var result = "";
       if (method) {
-          var types = {
-              GET: "-X GET",
-              POST: "-X POST",
-              PUT: "-X PUT",
-              PATCH: "-X PATCH",
-              DELETE: "-X DELETE",
-              HEAD: "-X HEAD",
-              OPTIONS: "-X OPTIONS",
-              CONNECT: "-X CONNECT",
-              TRACE: "-X TRACE",
-              QUERY: "-X QUERY",
-          };
-          result = " " + types[method.toUpperCase()];
+          if (noValidation) {
+              result = " -X " + method;
+          }
+          else {
+              var types = {
+                  GET: "-X GET",
+                  POST: "-X POST",
+                  PUT: "-X PUT",
+                  PATCH: "-X PATCH",
+                  DELETE: "-X DELETE",
+                  HEAD: "-X HEAD",
+                  OPTIONS: "-X OPTIONS",
+                  CONNECT: "-X CONNECT",
+                  TRACE: "-X TRACE",
+                  QUERY: "-X QUERY",
+              };
+              result = " " + types[method.toUpperCase()];
+          }
       }
       return slash + newLine + result;
   };
@@ -169,7 +175,7 @@
   var CurlGenerator = function (params, options) {
       var curlSnippet = "curl ";
       curlSnippet += params.url;
-      curlSnippet += getCurlMethod(params.method);
+      curlSnippet += getCurlMethod(params.method, params.noValidation);
       curlSnippet += getCurlHeaders(params.headers);
       curlSnippet += getCurlBody(params.body);
       curlSnippet += getCurlOptions(options);

--- a/dist/main.d.ts
+++ b/dist/main.d.ts
@@ -49,6 +49,7 @@ declare type CurlAdditionalOptions = {
 };
 declare type CurlRequest = {
     method?: "GET" | "get" | "POST" | "post" | "PUT" | "put" | "PATCH" | "patch" | "DELETE" | "delete" | "HEAD" | "head" | "OPTIONS" | "options" | "CONNECT" | "connect" | "TRACE" | "trace" | "QUERY" | "query";
+    noValidation?: boolean;
     headers?: StringMap;
     body?: CurlBody;
     url: string;

--- a/example/parameters.ts
+++ b/example/parameters.ts
@@ -203,3 +203,12 @@ export const queryRequest = {
     "Accept-Query": "application/jsonpath",
   }
 }
+
+export const copyRequest = {
+  url: "http://copy.example.com",
+  method: "COPY",
+  noValidation: true,
+  headers: {
+    "Content-Type": "application/json",
+  }
+}

--- a/example/parameters.ts
+++ b/example/parameters.ts
@@ -195,3 +195,11 @@ export const jsonBody = {
     },
   },
 };
+
+export const queryRequest = {
+  url: "http://query.example.com",
+  method: "query",
+  headers: {
+    "Accept-Query": "application/jsonpath",
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,6 +51,7 @@ type CurlAdditionalOptions = {
 type CurlRequest = {
   // Query is not official HTTP method, but it's in a RFC and we want to support it. https://datatracker.ietf.org/doc/html/draft-ietf-httpbis-safe-method-w-body
   method?: "GET" | "get" | "POST" | "post" | "PUT" | "put" | "PATCH" | "patch" | "DELETE" | "delete" | "HEAD" | "head" | "OPTIONS" | "options" | "CONNECT" | "connect" | "TRACE" | "trace" | "QUERY" | "query",
+  noValidation?: boolean,
   headers?: StringMap,
   body?: CurlBody,
   url: string,
@@ -62,24 +63,29 @@ const newLine = "\n";
 
 /**
  * @param {string} [method]
+ * @param {boolean} [noValidation]
  * @returns {string}
  */
-const getCurlMethod = function (method?: string): string {
+const getCurlMethod = function (method?: string, noValidation?: boolean): string {
   let result: string = "";
   if (method) {
-    const types: StringMap = {
-      GET: "-X GET",
-      POST: "-X POST",
-      PUT: "-X PUT",
-      PATCH: "-X PATCH",
-      DELETE: "-X DELETE",
-      HEAD: "-X HEAD",
-      OPTIONS: "-X OPTIONS",
-      CONNECT: "-X CONNECT",
-      TRACE: "-X TRACE",
-      QUERY: "-X QUERY",
-    };
-    result = ` ${types[method.toUpperCase()]}`;
+    if (noValidation) {
+      result = ` -X ${method}`;
+    } else {
+      const types: StringMap = {
+        GET: "-X GET",
+        POST: "-X POST",
+        PUT: "-X PUT",
+        PATCH: "-X PATCH",
+        DELETE: "-X DELETE",
+        HEAD: "-X HEAD",
+        OPTIONS: "-X OPTIONS",
+        CONNECT: "-X CONNECT",
+        TRACE: "-X TRACE",
+        QUERY: "-X QUERY",
+      };
+      result = ` ${types[method.toUpperCase()]}`;
+    }
   }
   return slash + newLine + result;
 };
@@ -155,7 +161,7 @@ const CurlGenerator = function (
 ): string {
   let curlSnippet = "curl ";
   curlSnippet += params.url;
-  curlSnippet += getCurlMethod(params.method);
+  curlSnippet += getCurlMethod(params.method, params.noValidation);
   curlSnippet += getCurlHeaders(params.headers);
   curlSnippet += getCurlBody(params.body);
   curlSnippet += getCurlOptions(options);

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -1,5 +1,11 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`copyRequest 1`] = `
+"curl http://copy.example.com \\
+ -X COPY \\
+ -H 'Content-Type: application/json'"
+`;
+
 exports[`del1 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts/1 \\
  -X DELETE"

--- a/test/__snapshots__/main.test.ts.snap
+++ b/test/__snapshots__/main.test.ts.snap
@@ -99,6 +99,12 @@ exports[`put1 1`] = `
  -d '{"id":1,"title":"foo","body":"barzzz","userId":1}'"
 `;
 
+exports[`queryRequest 1`] = `
+"curl http://query.example.com \\
+ -X QUERY \\
+ -H 'Accept-Query: application/jsonpath'"
+`;
+
 exports[`rawBody1 1`] = `
 "curl https://jsonplaceholder.typicode.com/posts \\
  -X POST \\


### PR DESCRIPTION
Include boolean parameter `noValidation`,
that allows any method.

Adapt generated files dist/* via running `npm run dev`.

Add new test scenario in example parameters,
when unknown verb is provided.
for example 'copy', old WebDev method,
cf [rfc 2518](https://www.rfc-editor.org/rfc/rfc2518#section-8.8).


PS: This PR contains also an independent commit, adding new test scenario for method 'query ' (available si #26).
I can move this commit in a dedicated PR if you want

----

following [suggestion](https://github.com/albertodeago/curl-generator/issues/25#issuecomment-3422613858) from issue #25 